### PR TITLE
Fix non-positive file size limit not working

### DIFF
--- a/plog-printer/src/main/java/org/mym/plog/printer/FilePrinter.java
+++ b/plog-printer/src/main/java/org/mym/plog/printer/FilePrinter.java
@@ -278,7 +278,7 @@ public class FilePrinter extends AbsPrinter implements Closeable {
             //single log length (content) may over limit; but needn't to care this situation
             // because it's still safe.
             if (mCurrentFile != null
-                    && (mCurrentFile.length() + content.length() > logger.mFileSizeLimit)) {
+                    && (logger.mFileSizeLimit > 0 && mCurrentFile.length() + content.length() > logger.mFileSizeLimit)) {
                 resetOutputStream();
             }
 


### PR DESCRIPTION
According to the document, a non-positive `fileSizeLimit` argument indicates no limitation.