### PR TITLE
Fix message printed twice when a throwable is given

### DIFF
--- a/plog-formatter/build.gradle
+++ b/plog-formatter/build.gradle
@@ -8,6 +8,7 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.MIN_SDK_VERSION as int
         targetSdkVersion rootProject.ext.TARGET_SDK_VERSION as int
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     packagingOptions {
@@ -25,6 +26,9 @@ dependencies {
     //For develop only
     provided project(':plog')
     provided "com.android.support:support-annotations:${rootProject.ext.SUPPORT_VERSION as String}"
+    androidTestImplementation project(':plog')
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
 }
 
 publish {

--- a/plog-formatter/src/androidTest/java/org/mym/plog/formatter/DefaultFormatterTest.java
+++ b/plog-formatter/src/androidTest/java/org/mym/plog/formatter/DefaultFormatterTest.java
@@ -1,0 +1,21 @@
+package org.mym.plog.formatter;
+
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mym.plog.Formatter;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class DefaultFormatterTest {
+    @Test
+    public void testFormatThrowableParams() throws Exception {
+        Formatter formatter = new DefaultFormatter();
+        Throwable throwable = new Throwable("Test");
+        String formatted = formatter.format("Throwable is %s", throwable);
+        assertEquals("Throwable is " + Log.getStackTraceString(throwable), formatted);
+    }
+}

--- a/plog-formatter/src/main/java/org/mym/plog/formatter/DefaultFormatter.java
+++ b/plog-formatter/src/main/java/org/mym/plog/formatter/DefaultFormatter.java
@@ -119,7 +119,7 @@ public class DefaultFormatter implements Formatter {
             boolean formatted = false;
             for (FormatterImpl impl : mFormatterImpls) {
                 if (isFormatterAvailable(impl.typeFlag, param, impl.supportedClass)){
-                    formattedParam[i] = impl.formatter.format(msg, param);
+                    formattedParam[i] = impl.formatter.format("", param);
                     formatted = true;
                     break;
                 }


### PR DESCRIPTION
When calling `PLog.level(level).tag(tag).msg("The throwable is %s").throwable(throwable).print()` with `DefaultFormatter` configured, it prints out:

```
The throwable is The throwable is %sjava.lang.Throwable:...
```

But the expected result is:

```
The throwable is java.lang.Throwable:...
```

This patch fixes the issue.